### PR TITLE
Remove ValidateConfig from Provider interface to restore 4-method RPC…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(find:*)",
       "Bash(go run:*)",
       "Bash(go mod:*)",
-      "Bash(go clean:*)"
+      "Bash(go clean:*)",
+      "Read(//mnt/c/git/Kolumn-providers-database/**)"
     ],
     "deny": [],
     "ask": []

--- a/4-METHOD-PATTERN.md
+++ b/4-METHOD-PATTERN.md
@@ -1,0 +1,77 @@
+# The 4-Method RPC Pattern
+
+## Overview
+
+The Kolumn Provider SDK enforces a **strict 4-method RPC interface** for all providers. This architectural constraint ensures:
+
+- **Clean RPC communication** with Kolumn core
+- **Interface consistency** across all providers
+- **No method bloat** or unnecessary complexity
+- **Performance optimization** by avoiding extra RPC calls
+
+## The 4 Required Methods
+
+```go
+type Provider interface {
+    // RPC Method 1: Configure the provider
+    Configure(ctx context.Context, config map[string]interface{}) error
+
+    // RPC Method 2: Return provider schema and capabilities
+    Schema() (*Schema, error)
+
+    // RPC Method 3: Handle all resource operations via unified dispatch
+    CallFunction(ctx context.Context, function string, input []byte) ([]byte, error)
+
+    // RPC Method 4: Clean up provider resources
+    Close() error
+}
+```
+
+## ⚠️ What Was Removed: ValidateConfig
+
+**ValidateConfig was intentionally removed** to maintain the 4-method pattern.
+
+### ❌ Old Pattern (REMOVED)
+```go
+// This 5th method violated the 4-method pattern and was removed
+func (p *Provider) ValidateConfig(ctx context.Context, config map[string]interface{}) *ConfigValidationResult
+```
+
+### ✅ New Pattern (RECOMMENDED)
+```go
+// Validation now happens within Configure()
+func (p *Provider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Validate configuration first
+    if err := p.validateConfiguration(ctx, config); err != nil {
+        return fmt.Errorf("configuration validation failed: %w", err)
+    }
+
+    // Apply configuration after validation
+    return p.applyConfig(config)
+}
+```
+
+## Why This Matters
+
+1. **Core Compatibility** - Kolumn core expects exactly 4 RPC methods
+2. **Interface Purity** - Clean, minimal interface without bloat
+3. **Performance** - No separate validation RPC calls
+4. **Architectural Consistency** - All providers follow same pattern
+
+## Resources
+
+- **[README.md](./README.md)** - Full SDK documentation
+- **[CLAUDE.md](./CLAUDE.md)** - Development guidance
+- **[docs/VALIDATION_GUIDE.md](./docs/VALIDATION_GUIDE.md)** - Comprehensive validation patterns
+- **[examples/simple/provider.go](./examples/simple/provider.go)** - Working example
+
+## Quick Migration
+
+If you have existing ValidateConfig methods:
+
+1. **Move validation logic** into `Configure()` method
+2. **Use validation helpers** from `helpers/validation/` package
+3. **Test configuration** during Configure, not separately
+4. **Return errors** directly from Configure for invalid config
+
+See [docs/VALIDATION_GUIDE.md](./docs/VALIDATION_GUIDE.md) for detailed migration examples.

--- a/core/provider.go
+++ b/core/provider.go
@@ -26,6 +26,13 @@ const (
 )
 
 // Provider is the core interface that all Kolumn providers must implement.
+//
+// ⚠️ CRITICAL: This interface MUST have exactly 4 methods - no more, no less.
+// This enforces the 4-method RPC pattern that maintains compatibility with Kolumn core.
+//
+// ValidateConfig was intentionally REMOVED to maintain interface purity.
+// Use validation helpers within Configure() instead of separate validation methods.
+//
 // This is the minimum interface - dead simple to get started.
 type Provider interface {
 	// Configure sets up the provider with the given configuration
@@ -34,10 +41,6 @@ type Provider interface {
 
 	// Schema returns the provider's schema definition
 	Schema() (*Schema, error)
-
-	// ValidateConfig validates the provider configuration using the validation framework
-	// Returns detailed validation results with errors, warnings, and fix suggestions
-	ValidateConfig(ctx context.Context, config map[string]interface{}) *ConfigValidationResult
 
 	// CallFunction executes a provider function with unified dispatch
 	// Supports function names: CreateResource, ReadResource, UpdateResource, DeleteResource, etc.
@@ -1219,7 +1222,7 @@ func (bp *BaseProvider) SetSchema(schema *Schema) {
 	bp.schema = schema
 }
 
-// GetSchema returns the provider schema (for use in default ValidateConfig)
+// GetSchema returns the provider schema (for use in internal validation)
 func (bp *BaseProvider) GetSchema() *Schema {
 	return bp.schema
 }
@@ -1234,8 +1237,8 @@ func (bp *BaseProvider) AddValidationRules(rules []ConfigValidationRule) {
 	bp.validator.AddRules(rules)
 }
 
-// ValidateConfig provides a default implementation using the schema and validation framework
-func (bp *BaseProvider) ValidateConfig(ctx context.Context, config map[string]interface{}) *ConfigValidationResult {
+// ValidateConfiguration provides a helper method for internal configuration validation using the schema and validation framework
+func (bp *BaseProvider) ValidateConfiguration(ctx context.Context, config map[string]interface{}) *ConfigValidationResult {
 	// Store config for potential use by other methods
 	bp.config = config
 

--- a/docs/VALIDATION_GUIDE.md
+++ b/docs/VALIDATION_GUIDE.md
@@ -1,0 +1,302 @@
+# Provider Validation Guide
+
+## 4-Method Pattern and Validation
+
+The Kolumn Provider SDK enforces a **strict 4-method RPC interface**. Configuration validation is **NOT** a separate RPC method but should be handled internally within the `Configure()` method.
+
+## ❌ What Was Removed
+
+The `ValidateConfig` method was removed from the Provider interface:
+
+```go
+// ❌ NO LONGER EXISTS - This method was removed to maintain 4-method pattern
+func (p *Provider) ValidateConfig(ctx context.Context, config map[string]interface{}) *ConfigValidationResult
+```
+
+## ✅ Recommended Validation Patterns
+
+### Pattern 1: Direct Validation in Configure
+
+```go
+func (p *MyProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Step 1: Security validation (always do this first)
+    validator := &security.InputSizeValidator{}
+    if err := validator.ValidateConfigSize(config); err != nil {
+        return security.NewSecureError(
+            "configuration too large",
+            fmt.Sprintf("config validation failed: %v", err),
+            "CONFIG_TOO_LARGE",
+        )
+    }
+
+    // Step 2: Required field validation
+    host, ok := config["host"].(string)
+    if !ok || host == "" {
+        return security.NewSecureError(
+            "missing required configuration",
+            "host field is required and must be a non-empty string",
+            "MISSING_HOST",
+        )
+    }
+
+    port, ok := config["port"].(int)
+    if !ok {
+        return security.NewSecureError(
+            "invalid configuration",
+            "port field must be an integer",
+            "INVALID_PORT",
+        )
+    }
+
+    // Step 3: Business logic validation
+    if port < 1 || port > 65535 {
+        return security.NewSecureError(
+            "invalid configuration",
+            "port must be between 1 and 65535",
+            "INVALID_PORT_RANGE",
+        )
+    }
+
+    // Step 4: Apply configuration if validation passes
+    p.host = host
+    p.port = port
+
+    return nil
+}
+```
+
+### Pattern 2: Using Validation Framework
+
+```go
+func (p *MyProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Use the SDK validation framework
+    validators := map[string]validation.ValidationFunc{
+        "host": validation.RequiredString(),
+        "port": validation.PortNumber(),
+        "database": validation.RequiredString(),
+        "username": validation.OptionalString(),
+        "password": validation.OptionalString(),
+    }
+
+    if err := validation.ValidateConfig(config, validators); err != nil {
+        return fmt.Errorf("configuration validation failed: %w", err)
+    }
+
+    // Apply validated configuration
+    return p.applyConfig(config)
+}
+```
+
+### Pattern 3: Using BaseProvider Helper
+
+```go
+type MyProvider struct {
+    *core.BaseProvider
+    // your fields...
+}
+
+func NewMyProvider() *MyProvider {
+    base := core.NewBaseProvider("my-provider")
+
+    // Add validation rules to base provider
+    base.AddValidationRules([]core.ConfigValidationRule{
+        {
+            Field:       "host",
+            Required:    true,
+            Type:        "string",
+            Description: "Database host address",
+            Custom:      validation.ValidateHost,
+        },
+        {
+            Field:       "port",
+            Required:    true,
+            Type:        "int",
+            Description: "Database port number",
+            Custom:      validation.ValidatePort,
+        },
+    })
+
+    return &MyProvider{
+        BaseProvider: base,
+    }
+}
+
+func (p *MyProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Use BaseProvider validation helper
+    if result := p.ValidateConfiguration(ctx, config); !result.IsValid() {
+        return fmt.Errorf("configuration validation failed: %v", result.Errors)
+    }
+
+    // Apply configuration
+    return p.applyConfig(config)
+}
+```
+
+## Security Best Practices
+
+### Always Validate Input Size First
+
+```go
+func (p *MyProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // SECURITY: Always validate input size first to prevent DoS attacks
+    validator := &security.InputSizeValidator{}
+    if err := validator.ValidateConfigSize(config); err != nil {
+        return security.NewSecureError(
+            "configuration too large",
+            fmt.Sprintf("config validation failed: %v", err),
+            "CONFIG_TOO_LARGE",
+        )
+    }
+
+    // Continue with other validation...
+}
+```
+
+### Use Secure Error Handling
+
+```go
+// ✅ CORRECT - Use SecureError for consistent error handling
+return security.NewSecureError(
+    "invalid configuration",        // User-friendly message
+    "detailed internal message",    // Debug information
+    "ERROR_CODE",                  // Machine-readable error code
+)
+
+// ❌ INCORRECT - Don't expose internal details
+return fmt.Errorf("failed to connect to database at %s:%d with credentials %s:%s", host, port, user, pass)
+```
+
+## Common Validation Patterns
+
+### Database Connection Validation
+
+```go
+func (p *DatabaseProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Extract and validate connection parameters
+    dsn, err := p.buildDSN(config)
+    if err != nil {
+        return fmt.Errorf("invalid connection configuration: %w", err)
+    }
+
+    // Test connection during configuration
+    db, err := sql.Open(p.driverName, dsn)
+    if err != nil {
+        return fmt.Errorf("failed to open database connection: %w", err)
+    }
+    defer db.Close()
+
+    if err := db.PingContext(ctx); err != nil {
+        return fmt.Errorf("failed to ping database: %w", err)
+    }
+
+    // Store validated configuration
+    p.dsn = dsn
+    return nil
+}
+```
+
+### API Client Validation
+
+```go
+func (p *APIProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Validate API configuration
+    endpoint, ok := config["endpoint"].(string)
+    if !ok {
+        return fmt.Errorf("endpoint is required")
+    }
+
+    apiKey, ok := config["api_key"].(string)
+    if !ok {
+        return fmt.Errorf("api_key is required")
+    }
+
+    // Validate endpoint URL
+    if _, err := url.Parse(endpoint); err != nil {
+        return fmt.Errorf("invalid endpoint URL: %w", err)
+    }
+
+    // Test API connectivity
+    client := &http.Client{Timeout: 10 * time.Second}
+    req, _ := http.NewRequestWithContext(ctx, "GET", endpoint+"/health", nil)
+    req.Header.Set("Authorization", "Bearer "+apiKey)
+
+    resp, err := client.Do(req)
+    if err != nil {
+        return fmt.Errorf("failed to connect to API: %w", err)
+    }
+    resp.Body.Close()
+
+    if resp.StatusCode >= 400 {
+        return fmt.Errorf("API returned error status: %d", resp.StatusCode)
+    }
+
+    // Store validated configuration
+    p.endpoint = endpoint
+    p.apiKey = apiKey
+    return nil
+}
+```
+
+## Migration from ValidateConfig
+
+If you have existing code with ValidateConfig, migrate it like this:
+
+### Before (DEPRECATED)
+
+```go
+func (p *MyProvider) ValidateConfig(ctx context.Context, config map[string]interface{}) *ConfigValidationResult {
+    // This method no longer exists
+    errors := []string{}
+    warnings := []string{}
+
+    if host, ok := config["host"].(string); !ok || host == "" {
+        errors = append(errors, "host is required")
+    }
+
+    return &ConfigValidationResult{
+        IsValid:  len(errors) == 0,
+        Errors:   errors,
+        Warnings: warnings,
+    }
+}
+
+func (p *MyProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Just apply config without validation
+    return p.applyConfig(config)
+}
+```
+
+### After (RECOMMENDED)
+
+```go
+func (p *MyProvider) Configure(ctx context.Context, config map[string]interface{}) error {
+    // Move validation logic into Configure
+    if host, ok := config["host"].(string); !ok || host == "" {
+        return fmt.Errorf("host is required")
+    }
+
+    // Apply configuration after validation
+    return p.applyConfig(config)
+}
+```
+
+## Best Practices Summary
+
+1. **✅ DO**: Validate within `Configure()` method
+2. **✅ DO**: Use security validation helpers for input size limits
+3. **✅ DO**: Test connectivity/authentication during configuration
+4. **✅ DO**: Use `SecureError` for consistent error handling
+5. **✅ DO**: Fail fast with clear error messages
+
+6. **❌ DON'T**: Add ValidateConfig method to Provider interface
+7. **❌ DON'T**: Skip input size validation
+8. **❌ DON'T**: Expose sensitive data in error messages
+9. **❌ DON'T**: Defer validation to runtime operations
+10. **❌ DON'T**: Break the 4-method RPC pattern
+
+## Reference
+
+- [Core Provider Interface](../core/provider.go)
+- [Validation Framework](../helpers/validation/)
+- [Security Helpers](../helpers/security/)
+- [Simple Provider Example](../examples/simple/provider.go)


### PR DESCRIPTION
… pattern

BREAKING CHANGE: ValidateConfig method removed from core.Provider interface

This change restores the strict 4-method RPC pattern that Kolumn core expects:
- Configure(ctx, config) error (RPC 1)
- Schema() (*Schema, error) (RPC 2)
- CallFunction(ctx, function, input) ([]byte, error) (RPC 3)
- Close() error (RPC 4)

WHY THIS CHANGE:
- ValidateConfig violated the 4-method architectural constraint
- Separate validation RPC calls add unnecessary overhead
- Configuration validation should be internal concern of Configure()
- Maintains interface purity and core compatibility

MIGRATION GUIDE:
- Move validation logic from ValidateConfig() into Configure() method
- Use SDK validation helpers within Configure() for robust validation
- Optional: Use BaseProvider.ValidateConfiguration() helper method

IMPACT ANALYSIS:
- ✅ No existing providers affected (they use StateBackendProvider.ValidateConfig)
- ✅ SDK maintains backward compatibility for all other interfaces
- ✅ Validation functionality preserved via helper methods and internal patterns

NEW DOCUMENTATION:
- 4-METHOD-PATTERN.md: Quick reference for the pattern
- docs/VALIDATION_GUIDE.md: Comprehensive validation migration guide
- Updated README.md and CLAUDE.md with detailed examples

🤖 Generated with [Claude Code](https://claude.ai/code)