### PR TITLE
fix(quarantine): microsecond timestamp prevents same-second name collisions

### DIFF
--- a/helpers/quarantine/quarantine.go
+++ b/helpers/quarantine/quarantine.go
@@ -12,7 +12,13 @@ const (
 	defaultPrefix       = "delete"
 	defaultMaxLength    = 255
 	minPrefixCharacters = 16
-	timeFormat          = "20060102T150405Z"
+	// timeFormat uses microsecond precision so two quarantine snapshots
+	// generated for the same table inside the same second don't collide
+	// (`pq: relation "..." already exists`). Observed end-to-end when two
+	// migrations target the same table back-to-back — the first migration
+	// snapshotted at second granularity and the second migration's apply
+	// failed because the destination table was already in kolumn_quarantine.
+	timeFormat = "20060102T150405.000000Z"
 )
 
 var sanitizeIdentifierPattern = regexp.MustCompile(`[^a-zA-Z0-9_]+`)


### PR DESCRIPTION
## Summary
Bumps quarantine name timestamps from second precision (\`20060102T150405Z\`) to microsecond precision (\`20060102T150405.000000Z\`) so two snapshots of the same table inside the same second don't collide.

## The bug
Caught running the core-api control-plane migrations end-to-end against a real postgres:

\`\`\`
[KOLUMN-INFO] apply: quarantine created at "kolumn_quarantine"."delete_table_20260428t010639z_schemabounce_core_roles"
[KOLUMN-INFO] applied operations: 1
... (next migration on the same table, ~10ms later) ...
[KOLUMN-ERROR] failed to create quarantine snapshot: pq: relation "delete_table_20260428t010639z_schemabounce_core_roles" already exists
\`\`\`

The \`dedup\` migration and the immediately-following \`fix.default_roles_is_system\` both target \`schemabounce_core.roles\` and ran inside the same wall-clock second. Their generated quarantine names were byte-identical.

## What changes
Just the format constant. The SHA-truncation path already kicks in when the resulting slug exceeds the provider's max identifier length, so the postgres 63-char limit is unaffected for normal table names.

## Test plan
- [x] \`go test ./helpers/quarantine/...\` — all green (TruncatesAndHashes still validates the 63-char path)
- [x] Local e2e against real postgres: the four core-api migrations on \`schemabounce_core.roles\` and friends now apply back-to-back without collision (microsecond suffix differs by ~120,000 µs between the two)

## Downstream
This SDK change unblocks the matching provider PR (precheck-coverage logic) — without microsecond precision the second-migration-on-the-same-table pattern still failed even with prechecks demoted.